### PR TITLE
Fix websocket not be able to subscribe to private order book

### DIFF
--- a/lib/ex_bitmex/ws.ex
+++ b/lib/ex_bitmex/ws.ex
@@ -51,8 +51,9 @@ defmodule ExBitmex.Ws do
       @impl true
       def handle_frame({:text, text}, state) do
         case Jason.decode(text) do
-          %{"request" => %{"op" => "authKey"}, "success" => true} ->
+          {:ok, %{"request" => %{"op" => "authKey"}, "success" => true} = payload} ->
             subscribe(self(), state[:auth_subscribe])
+            handle_response(payload, state)
 
           {:ok, payload} ->
             handle_response(payload, state)


### PR DESCRIPTION
We change the library from `Poison` to use `Jason` to parse json response. And `Jason` include `:ok` in the response which `Poison` didn't have that