### PR TITLE
Fix timeout issue

### DIFF
--- a/fixture/vcr_cassettes/rest/orders/cancel_bulk_timeout.json
+++ b/fixture/vcr_cassettes/rest/orders/cancel_bulk_timeout.json
@@ -1,0 +1,24 @@
+[
+  {
+    "request": {
+      "body": "{\"orders\":[{\"orderID\":\"5ba20261-b2dd-ea33-3720-b3211458b49f\"}]}",
+      "headers": {
+        "Content-Type": "application/json",
+        "api-nonce": "***",
+        "api-key": "***",
+        "api-signature": "***"
+      },
+      "method": "delete",
+      "options": [],
+      "request_body": "",
+      "url": "https://testnet.bitmex.com/api/v1/order/all"
+    },
+    "response": {
+      "binary": false,
+      "body": "timeout",
+      "headers": [],
+      "status_code": null,
+      "type": "error"
+    }
+  }
+]

--- a/lib/ex_bitmex/rest/http_client.ex
+++ b/lib/ex_bitmex/rest/http_client.ex
@@ -268,4 +268,8 @@ defmodule ExBitmex.Rest.HTTPClient do
   defp parse_response({:error, %HTTPoison.Error{reason: "timeout"}, rate_limit}) do
     {:error, :timeout, rate_limit}
   end
+
+  defp parse_response({:error, %HTTPoison.Error{reason: :timeout}, nil}) do
+    {:error, :timeout, nil}
+  end
 end

--- a/test/ex_bitmex/rest/orders/cancel_bulk_test.exs
+++ b/test/ex_bitmex/rest/orders/cancel_bulk_test.exs
@@ -106,4 +106,14 @@ defmodule ExBitmex.Rest.Orders.CancelBulkTest do
              ]
     end
   end
+
+  test ".cancel_bulk timeout" do
+    use_cassette "rest/orders/cancel_bulk_timeout" do
+      assert {:error, :timeout, _} =
+               ExBitmex.Rest.Orders.cancel_bulk(
+                 @credentials,
+                 %{orders: [%{orderID: "5ba20261-b2dd-ea33-3720-b3211458b49f"}]}
+               )
+    end
+  end
 end


### PR DESCRIPTION
implement `parse_response/1` -> this happen when there's no rate limit info in the header
initially only `parse_response/2` 