### PR TITLE
Handle 403 response with html from bitmex

### DIFF
--- a/fixture/custom_cassettes/rest/http_client/auth_request_error_403_forbidden.json
+++ b/fixture/custom_cassettes/rest/http_client/auth_request_error_403_forbidden.json
@@ -1,0 +1,30 @@
+[
+  {
+    "request": {
+        "body": "{\"orders\":[{\"orderID\":\"0c9223c2-b923-4599-ede7-d01adf51c655\",\"orderQty\":100,\"price\":3385.5},{\"orderID\":\"b4432a2b-0061-1b9d-9862-6cb8247aebbc\",\"orderQty\":100,\"price\":3382.0}]}",
+      "headers": {
+        "Content-Type": "application/json",
+        "api-nonce": "***",
+        "api-key": "***",
+        "api-signature": "***"
+      },
+      "method": "put",
+      "options": [],
+      "request_body": "",
+      "url": "https://testnet.bitmex.com/api/v1/order/bulk"
+    },
+    "response": {
+      "binary": false,
+      "body": "<html>\r\n<head><title>403 Forbidden</title></head>\r\n<body bgcolor=\"white\">\r\n<center><h1>403 Forbidden</h1></center>\r\n</body>\r\n</html>\r\n",
+      "headers": {
+        "Server": "awselb/2.0",
+        "Date": "Thu, 07 Feb 2019 10:42:12 GMT",
+        "Content-Type": "text/html",
+        "Content-Length": "138",
+        "Connection": "keep-alive"
+      },
+      "status_code": 403,
+      "type": "ok"
+    }
+  }
+]

--- a/test/ex_bitmex/rest/http_client_test.exs
+++ b/test/ex_bitmex/rest/http_client_test.exs
@@ -97,6 +97,13 @@ defmodule ExBitmex.Rest.HTTPClientTest do
       end
     end
 
+    test "returns an error tuple for 403 status code response with html body" do
+      use_cassette "rest/http_client/auth_request_error_403_forbidden", custom: true do
+        assert {:error, :banned, nil} =
+          ExBitmex.Rest.HTTPClient.auth_request(:put, "/order/bulk", @credentials, %{})
+      end
+    end
+
     test "returns an error tuple when the nonce is not increasing" do
       use_cassette "rest/http_client/auth_request_nonce_not_increasing" do
         assert {:error, {:nonce_not_increasing, msg}, _} =


### PR DESCRIPTION
When we hit rate limit and get banneed, we are receiving 403 error with
html. This commit handles it