### PR TITLE
Fix rate limit headers sometimes cannot be parsed correctly

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,10 @@
 language: elixir
 
 elixir:
-  - '1.7'
-  - '1.8'
-otp_release: '21.0'
+  - '1.9.1'
+otp_release: '22.0.7'
+
+env:
+  global:
+    - BITMEX_API_KEY=fake-api-key
+    - BITMEX_API_SECRET=fake-api-secret

--- a/lib/ex_bitmex/rest/http_client.ex
+++ b/lib/ex_bitmex/rest/http_client.ex
@@ -137,9 +137,9 @@ defmodule ExBitmex.Rest.HTTPClient do
     Keyword.put(headers, :"Content-Type", "application/json")
   end
 
-  @limit_header "X-RateLimit-Limit"
-  @remaining_header "X-RateLimit-Remaining"
-  @reset_header "X-RateLimit-Reset"
+  @limit_header "x-ratelimit-limit"
+  @remaining_header "x-ratelimit-remaining"
+  @reset_header "x-ratelimit-reset"
 
   defp parse_rate_limits({result, %HTTPoison.Response{headers: headers} = response}) do
     limit_headers =
@@ -147,7 +147,7 @@ defmodule ExBitmex.Rest.HTTPClient do
       |> Enum.reduce(
         %{},
         fn {k, v}, acc ->
-          case k do
+          case String.downcase(k) do
             @limit_header -> Map.put(acc, :limit, v)
             @remaining_header -> Map.put(acc, :remaining, v)
             @reset_header -> Map.put(acc, :reset, v)

--- a/test/ex_bitmex/rest/orders/amend_bulk_test.exs
+++ b/test/ex_bitmex/rest/orders/amend_bulk_test.exs
@@ -9,7 +9,7 @@ defmodule ExBitmex.Rest.Orders.AmendBulkTest do
 
   @credentials %ExBitmex.Credentials{
     api_key: System.get_env("BITMEX_API_KEY"),
-    api_secret: System.get_env("BITMEX_SECRET")
+    api_secret: System.get_env("BITMEX_API_SECRET")
   }
 
   test ".amend_bulk returns the order response" do

--- a/test/ex_bitmex/rest/orders/amend_test.exs
+++ b/test/ex_bitmex/rest/orders/amend_test.exs
@@ -9,7 +9,7 @@ defmodule ExBitmex.Rest.Orders.AmendTest do
 
   @credentials %ExBitmex.Credentials{
     api_key: System.get_env("BITMEX_API_KEY"),
-    api_secret: System.get_env("BITMEX_SECRET")
+    api_secret: System.get_env("BITMEX_API_SECRET")
   }
 
   test ".amend returns the order response" do

--- a/test/ex_bitmex/rest/orders/cancel_bulk_test.exs
+++ b/test/ex_bitmex/rest/orders/cancel_bulk_test.exs
@@ -9,7 +9,7 @@ defmodule ExBitmex.Rest.Orders.CancelBulkTest do
 
   @credentials %ExBitmex.Credentials{
     api_key: System.get_env("BITMEX_API_KEY"),
-    api_secret: System.get_env("BITMEX_SECRET")
+    api_secret: System.get_env("BITMEX_API_SECRET")
   }
 
   test ".cancel_bulk returns a list of results" do

--- a/test/ex_bitmex/rest/orders/cancel_test.exs
+++ b/test/ex_bitmex/rest/orders/cancel_test.exs
@@ -10,7 +10,7 @@ defmodule ExBitmex.Rest.Orders.CancelTest do
 
   @credentials %ExBitmex.Credentials{
     api_key: System.get_env("BITMEX_API_KEY"),
-    api_secret: System.get_env("BITMEX_SECRET")
+    api_secret: System.get_env("BITMEX_API_SECRET")
   }
 
   test ".cancel returns a list of results" do

--- a/test/ex_bitmex/rest/orders/create_bulk_test.exs
+++ b/test/ex_bitmex/rest/orders/create_bulk_test.exs
@@ -9,7 +9,7 @@ defmodule ExBitmex.Rest.Orders.CreateBulkTest do
 
   @credentials %ExBitmex.Credentials{
     api_key: System.get_env("BITMEX_API_KEY"),
-    api_secret: System.get_env("BITMEX_SECRET")
+    api_secret: System.get_env("BITMEX_API_SECRET")
   }
 
   test ".create_bulk returns the order response" do

--- a/test/ex_bitmex/rest/orders/create_test.exs
+++ b/test/ex_bitmex/rest/orders/create_test.exs
@@ -9,7 +9,7 @@ defmodule ExBitmex.Rest.Orders.CreateTest do
 
   @credentials %ExBitmex.Credentials{
     api_key: System.get_env("BITMEX_API_KEY"),
-    api_secret: System.get_env("BITMEX_SECRET")
+    api_secret: System.get_env("BITMEX_API_SECRET")
   }
 
   test ".create returns the order response" do

--- a/test/ex_bitmex/rest/positions_test.exs
+++ b/test/ex_bitmex/rest/positions_test.exs
@@ -10,7 +10,7 @@ defmodule ExBitmex.Rest.PositionsTest do
 
   @credentials %ExBitmex.Credentials{
     api_key: System.get_env("BITMEX_API_KEY"),
-    api_secret: System.get_env("BITMEX_SECRET")
+    api_secret: System.get_env("BITMEX_API_SECRET")
   }
 
   test ".all returns a list of positions" do


### PR DESCRIPTION
BitMEX returns rate limit information in the header response like:

```
{"X-RateLimit-Limit", "60"},
{"X-RateLimit-Remaining", "59"},
{"X-RateLimit-Reset", "1597041633"}
```

and sometimes like this:

```
{"x-ratelimit-limit", "60"},
{"x-ratelimit-remaining", "59"},
{"x-ratelimit-reset", "1597041676"},
```

So we need to handle both cases.